### PR TITLE
Add positional embeddings

### DIFF
--- a/svglatte/dataset/argoverse_dataset.py
+++ b/svglatte/dataset/argoverse_dataset.py
@@ -14,7 +14,7 @@ from deepsvg.difflib.tensor import SVGTensor
 from deepsvg.svg_dataset import SVGDataset
 from deepsvg.svglib.geom import Bbox, Angle, Point
 from deepsvg.svglib.svg import SVG
-from svglatte.utils.util import pad_collate_fn
+from svglatte.utils.util import pad_collate_fn, Embedder
 
 CMDS_CLASSES = 7
 ARGS_GROUPED_DIM = 13  # 11 + 2
@@ -290,6 +290,7 @@ class ArgoverseDataModule(pl.LightningDataModule):
             augment_train=True,
             augment_val=False,
             augment_test=False,
+            embedding_style=None,
 
             **kwargs
     ):
@@ -318,8 +319,10 @@ class ArgoverseDataModule(pl.LightningDataModule):
 
         self._setup_called = False
 
+        self.embedder = Embedder.factory(embedding_style) if embedding_style is not None else None
+
         def collate_fn(batch):
-            return pad_collate_fn(batch, self.pad_val)
+            return pad_collate_fn(batch, self.pad_val, self.embedder)
 
         self.collate_fn = collate_fn if not self.dataset_kwargs['return_deepsvg_model_input'] else None
 

--- a/svglatte/dataset/deepsvg_dataset.py
+++ b/svglatte/dataset/deepsvg_dataset.py
@@ -193,7 +193,8 @@ def load_dataset_splits(
         test_ratio=0.15,
         cache_to_disk=True,
         clean_disk_cache=False,
-        seed=72
+        seed=72,
+        embedding_style=None,
 ):
     train_df_cache_path = os.path.join(data_root, f"train_df.csv") if cache_to_disk else None
     val_df_cache_path = os.path.join(data_root, f"val_df.csv") if cache_to_disk else None
@@ -251,8 +252,10 @@ def load_dataset_splits(
     val_ds = DeepSVGDatasetNoCache(val_svgtensor_ds)
     test_ds = DeepSVGDatasetNoCache(test_svgtensor_ds)
 
+    embedder = Embedder.factory(embedding_style) if embedding_style is not None else None
+
     def collate_fn(batch):
-        return pad_collate_fn(batch, train_svgtensor_ds.PAD_VAL)
+        return pad_collate_fn(batch, train_svgtensor_ds.PAD_VAL, embedder)
 
     return train_ds, val_ds, test_ds, collate_fn
 
@@ -268,6 +271,7 @@ class DeepSVGDataModule(pl.LightningDataModule):
             batch_size: int = 32,
             cache_to_disk=True,
             clean_disk_cache=False,
+            embedding_style=None,
     ):
         super(DeepSVGDataModule, self).__init__()
         self.batch_size = batch_size
@@ -279,7 +283,8 @@ class DeepSVGDataModule(pl.LightningDataModule):
             max_seq_len=max_seq_len,
             max_total_len=max_total_len,
             cache_to_disk=cache_to_disk,
-            clean_disk_cache=clean_disk_cache
+            clean_disk_cache=clean_disk_cache,
+            embedding_style=embedding_style,
         )
 
         self.train_mean = self.train_ds.seq_mean

--- a/svglatte/scripts/slurm/sbatch/sbatch_12/svglatte-12-05--bs-256--continue.sh
+++ b/svglatte/scripts/slurm/sbatch/sbatch_12/svglatte-12-05--bs-256--continue.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+#SBATCH --chdir /scratch/izar/rajic/svg-latte
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1
+#SBATCH --cpus-per-task=40
+#SBATCH --mem=370G
+#SBATCH --partition=gpu
+#SBATCH --reservation=vita
+#SBATCH --qos=gpu
+#SBATCH --gres=gpu:2
+#SBATCH --time=72:00:00
+
+#SBATCH -o ./slurm_logs/%x-%j.out
+
+set -e
+set -o xtrace
+echo PWD:$(pwd)
+echo STARTING AT $(date)
+
+# Modules
+module purge
+module load gcc/9.3.0-cuda
+module load cuda/11.0.2
+
+# Environment
+source ~/miniconda3/etc/profile.d/conda.sh
+conda activate svglatte-pl
+export PYTHONPATH="$PYTHONPATH:$PWD/deepsvg"
+
+# Run
+date
+printf "Run configured and environment set up. Gonna run now.\n\n"
+python -m svglatte.train \
+ --experiment_name svg-latte-hparamsearch \
+ --experiment_version 'S12.05__BestHparams__Seed=36_02.06_15.32.38' \
+ --seed 36 \
+ --gpus -1 \
+ --n_epochs 600 \
+ --early_stopping_patience 80 \
+ --check_val_every_n_epoch 20 \
+ --batch_size 256 \
+ --encoder_lr 0.00042 \
+ --decoder_lr 2.1e-05 \
+ --encoder_weight_decay 0.0 \
+ --decoder_weight_decay 0.0 \
+ --encoder_type fc_lstm \
+ --lstm_num_layers 8 \
+ --latte_ingredients c \
+ --decoder_n_filters_in_last_conv_layer 16 \
+ --no_layernorm \
+ --cx_loss_w 0.0 \
+ --dataset argoverse \
+ --argoverse_sequences_format svgtensor_data \
+ --argoverse_train_sequences_path data/argoverse/train.sequences.torchsave \
+ --argoverse_val_sequences_path data/argoverse/val.sequences.torchsave \
+ --argoverse_test_sequences_path data/argoverse/test.sequences.torchsave \
+ --argoverse_train_workers 40 \
+ --argoverse_val_workers 3 \
+ --argoverse_rendered_images_width 128 \
+ --argoverse_rendered_images_height 128 \
+ --argoverse_augment_train --argoverse_zoom_preprocess_factor 0.70710678118 \
+ --precision 16 \
+ --gradient_clip_val 1.0 \
+ --do_not_add_timestamp_to_experiment_version --checkpoint_path logs/svg-latte-hparamsearch/S12.05__BestHparams__Seed-36_02.06_15.32.38_S12.05__BestHparams__Seed=36_02.06_15.32.38/checkpoints/epoch=399-step=322000.ckpt
+
+echo FINISHED at $(date)

--- a/svglatte/scripts/slurm/sbatch/sbatch_12/svglatte-12-05--bs-256--test.sh
+++ b/svglatte/scripts/slurm/sbatch/sbatch_12/svglatte-12-05--bs-256--test.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+#SBATCH --chdir /scratch/izar/rajic/svg-latte
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1
+#SBATCH --cpus-per-task=20
+#SBATCH --mem=180G
+#SBATCH --partition=gpu
+#SBATCH --qos=gpu
+#SBATCH --gres=gpu:1
+#SBATCH --time=03:00:00
+
+#SBATCH -o ./slurm_logs/%x-%j.out
+
+set -e
+set -o xtrace
+echo PWD:$(pwd)
+echo STARTING AT $(date)
+
+# Modules
+module purge
+module load gcc/9.3.0-cuda
+module load cuda/11.0.2
+
+# Environment
+source ~/miniconda3/etc/profile.d/conda.sh
+conda activate svglatte-pl
+export PYTHONPATH="$PYTHONPATH:$PWD/deepsvg"
+
+# Run
+date
+printf "Run configured and environment set up. Gonna run now.\n\n"
+python -m svglatte.train \
+ --experiment_name svg-latte-hparamsearch \
+ --experiment_version 'S12.05__BestHparams__Seed=36_02.06_15.32.38' \
+ --seed 36 \
+ --gpus -1 \
+ --n_epochs 600 \
+ --early_stopping_patience 80 \
+ --check_val_every_n_epoch 20 \
+ --batch_size 256 \
+ --encoder_lr 0.00042 \
+ --decoder_lr 2.1e-05 \
+ --encoder_weight_decay 0.0 \
+ --decoder_weight_decay 0.0 \
+ --encoder_type fc_lstm \
+ --lstm_num_layers 8 \
+ --latte_ingredients c \
+ --decoder_n_filters_in_last_conv_layer 16 \
+ --no_layernorm \
+ --cx_loss_w 0.0 \
+ --dataset argoverse \
+ --argoverse_sequences_format svgtensor_data \
+ --argoverse_train_sequences_path data/argoverse/train.sequences.torchsave \
+ --argoverse_val_sequences_path data/argoverse/val.sequences.torchsave \
+ --argoverse_test_sequences_path data/argoverse/test.sequences.torchsave \
+ --argoverse_train_workers 1 \
+ --argoverse_val_workers 1 \
+ --argoverse_test_workers 20 \
+ --argoverse_rendered_images_width 128 \
+ --argoverse_rendered_images_height 128 \
+ --argoverse_augment_train --argoverse_zoom_preprocess_factor 0.70710678118 \
+ --precision 16 \
+ --gradient_clip_val 1.0 \
+ --test_only --do_not_add_timestamp_to_experiment_version --checkpoint_path logs/svg-latte-hparamsearch/S12.05__BestHparams__Seed-36_02.06_15.32.38_S12.05__BestHparams__Seed=36_02.06_15.32.38/checkpoints/epoch=599-step=483000.ckpt
+
+echo FINISHED at $(date)

--- a/svglatte/scripts/slurm/sbatch/sbatch_12/svglatte-12-05--bs-256.sh
+++ b/svglatte/scripts/slurm/sbatch/sbatch_12/svglatte-12-05--bs-256.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+#SBATCH --chdir /scratch/izar/rajic/svg-latte
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1
+#SBATCH --cpus-per-task=40
+#SBATCH --mem=370G
+#SBATCH --partition=gpu
+#SBATCH --reservation=vita
+#SBATCH --qos=gpu
+#SBATCH --gres=gpu:2
+#SBATCH --time=72:00:00
+
+#SBATCH -o ./slurm_logs/%x-%j.out
+
+set -e
+set -o xtrace
+echo PWD:$(pwd)
+echo STARTING AT $(date)
+
+# Modules
+module purge
+module load gcc/9.3.0-cuda
+module load cuda/11.0.2
+
+# Environment
+source ~/miniconda3/etc/profile.d/conda.sh
+conda activate svglatte-pl
+export PYTHONPATH="$PYTHONPATH:$PWD/deepsvg"
+
+# Run
+date
+printf "Run configured and environment set up. Gonna run now.\n\n"
+python -m svglatte.train \
+ --experiment_name svg-latte-hparamsearch \
+ --experiment_version 'S12.05__BestHparams__Seed=36' \
+ --seed 36 \
+ --gpus -1 \
+ --n_epochs 400 \
+ --early_stopping_patience 80 \
+ --check_val_every_n_epoch 20 \
+ --batch_size 256 \
+ --encoder_lr 0.00042 \
+ --decoder_lr 2.1e-05 \
+ --encoder_weight_decay 0.0 \
+ --decoder_weight_decay 0.0 \
+ --encoder_type fc_lstm \
+ --lstm_num_layers 8 \
+ --latte_ingredients c \
+ --decoder_n_filters_in_last_conv_layer 16 \
+ --no_layernorm \
+ --cx_loss_w 0.0 \
+ --dataset argoverse \
+ --argoverse_sequences_format svgtensor_data \
+ --argoverse_train_sequences_path data/argoverse/train.sequences.torchsave \
+ --argoverse_val_sequences_path data/argoverse/val.sequences.torchsave \
+ --argoverse_test_sequences_path data/argoverse/test.sequences.torchsave \
+ --argoverse_train_workers 40 \
+ --argoverse_val_workers 3 \
+ --argoverse_rendered_images_width 128 \
+ --argoverse_rendered_images_height 128 \
+ --argoverse_augment_train --argoverse_zoom_preprocess_factor 0.70710678118 \
+ --precision 16 \
+ --gradient_clip_val 1.0 \
+
+echo FINISHED at $(date)

--- a/svglatte/scripts/slurm/sbatch/sbatch_15/svglatte-15-01.sh
+++ b/svglatte/scripts/slurm/sbatch/sbatch_15/svglatte-15-01.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+#SBATCH --chdir /scratch/izar/rajic/svg-latte
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1
+#SBATCH --cpus-per-task=40
+#SBATCH --mem=370G
+#SBATCH --partition=gpu
+#SBATCH --qos=gpu
+#SBATCH --gres=gpu:2
+#SBATCH --time=72:00:00
+
+#SBATCH -o ./slurm_logs/%x-%j.out
+
+set -e
+set -o xtrace
+echo PWD:$(pwd)
+echo STARTING AT $(date)
+
+# Modules
+module purge
+module load gcc/9.3.0-cuda
+module load cuda/11.0.2
+
+# Environment
+source ~/miniconda3/etc/profile.d/conda.sh
+conda activate svglatte-pl
+export PYTHONPATH="$PYTHONPATH:$PWD/deepsvg"
+
+# Run
+date
+printf "Run configured and environment set up. Gonna run now.\n\n"
+python -m svglatte.train \
+ --experiment_name svg-latte-hparamsearch \
+ --experiment_version 'S15.01__BestHparams__GaussianPositionalEncodings__Seed=72' \
+ --seed 72 \
+ --gpus -1 \
+ --n_epochs 600 \
+ --early_stopping_patience 80 \
+ --check_val_every_n_epoch 20 \
+ --batch_size 256 \
+ --encoder_lr 0.00042 \
+ --decoder_lr 2.1e-05 \
+ --encoder_weight_decay 0.0 \
+ --decoder_weight_decay 0.0 \
+ --encoder_type fc_lstm \
+ --lstm_num_layers 8 \
+ --latte_ingredients c \
+ --decoder_n_filters_in_last_conv_layer 16 \
+ --no_layernorm \
+ --cx_loss_w 0.0 \
+ --dataset argoverse \
+ --argoverse_sequences_format svgtensor_data \
+ --argoverse_train_sequences_path data/argoverse/train.sequences.torchsave \
+ --argoverse_val_sequences_path data/argoverse/val.sequences.torchsave \
+ --argoverse_test_sequences_path data/argoverse/test.sequences.torchsave \
+ --argoverse_train_workers 40 \
+ --argoverse_val_workers 3 \
+ --argoverse_rendered_images_width 128 \
+ --argoverse_rendered_images_height 128 \
+ --argoverse_augment_train --argoverse_zoom_preprocess_factor 0.70710678118 \
+ --precision 16 \
+ --gradient_clip_val 1.0 \
+ --seq_feature_dim 1028
+
+echo FINISHED at $(date)

--- a/svglatte/scripts/slurm/sbatch/sbatch_15/svglatte-15-01.sh
+++ b/svglatte/scripts/slurm/sbatch/sbatch_15/svglatte-15-01.sh
@@ -60,6 +60,7 @@ python -m svglatte.train \
  --argoverse_augment_train --argoverse_zoom_preprocess_factor 0.70710678118 \
  --precision 16 \
  --gradient_clip_val 1.0 \
- --seq_feature_dim 1028
+ --seq_feature_dim 1028 \
+ --embedding_style gaussian
 
 echo FINISHED at $(date)

--- a/svglatte/scripts/slurm/sbatch/sbatch_15/svglatte-15-02--test.sh
+++ b/svglatte/scripts/slurm/sbatch/sbatch_15/svglatte-15-02--test.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+#SBATCH --chdir /scratch/izar/rajic/svg-latte
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1
+#SBATCH --cpus-per-task=20
+#SBATCH --mem=180G
+#SBATCH --partition=gpu
+#SBATCH --qos=gpu
+#SBATCH --gres=gpu:1
+#SBATCH --time=03:00:00
+#SBATCH --reservation vita
+
+#SBATCH -o ./slurm_logs/%x-%j.out
+
+set -e
+set -o xtrace
+echo PWD:$(pwd)
+echo STARTING AT $(date)
+
+# Modules
+module purge
+module load gcc/9.3.0-cuda
+module load cuda/11.0.2
+
+# Environment
+source ~/miniconda3/etc/profile.d/conda.sh
+conda activate svglatte-pl
+export PYTHONPATH="$PYTHONPATH:$PWD/deepsvg"
+
+# Run
+date
+printf "Run configured and environment set up. Gonna run now.\n\n"
+python -m svglatte.train \
+ --experiment_name svg-latte-hparamsearch \
+ --experiment_version 'S15.02__BestHparams__NerfPositionalEncodings__Seed-72_02.04_21.59.40' \
+ --seed 72 \
+ --gpus -1 \
+ --n_epochs 600 \
+ --early_stopping_patience 80 \
+ --check_val_every_n_epoch 20 \
+ --batch_size 256 \
+ --encoder_lr 0.00042 \
+ --decoder_lr 2.1e-05 \
+ --encoder_weight_decay 0.0 \
+ --decoder_weight_decay 0.0 \
+ --encoder_type fc_lstm \
+ --lstm_num_layers 8 \
+ --latte_ingredients c \
+ --decoder_n_filters_in_last_conv_layer 16 \
+ --no_layernorm \
+ --cx_loss_w 0.0 \
+ --dataset argoverse \
+ --argoverse_sequences_format svgtensor_data \
+ --argoverse_train_sequences_path data/argoverse/train.sequences.torchsave \
+ --argoverse_val_sequences_path data/argoverse/val.sequences.torchsave \
+ --argoverse_test_sequences_path data/argoverse/test.sequences.torchsave \
+ --argoverse_train_workers 1 \
+ --argoverse_val_workers 1 \
+ --argoverse_test_workers 20 \
+ --argoverse_rendered_images_width 128 \
+ --argoverse_rendered_images_height 128 \
+ --argoverse_augment_train --argoverse_zoom_preprocess_factor 0.70710678118 \
+ --precision 16 \
+ --gradient_clip_val 1.0 \
+ --seq_feature_dim 120 \
+ --embedding_style nerf \
+ --test_only --do_not_add_timestamp_to_experiment_version --checkpoint_path logs/svg-latte-hparamsearch/S15.04__BestHparams__NerfPositionalEncodings__Seed-72_02.04_21.59.40_S15.04__BestHparams__NerfPositionalEncodings__Seed=72_02.04_21.59.40/checkpoints/epoch=559-step=450800.ckpt
+
+
+echo FINISHED at $(date)

--- a/svglatte/scripts/slurm/sbatch/sbatch_15/svglatte-15-02.sh
+++ b/svglatte/scripts/slurm/sbatch/sbatch_15/svglatte-15-02.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+#SBATCH --chdir /scratch/izar/rajic/svg-latte
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1
+#SBATCH --cpus-per-task=40
+#SBATCH --mem=370G
+#SBATCH --partition=gpu
+#SBATCH --qos=gpu
+#SBATCH --gres=gpu:2
+#SBATCH --time=72:00:00
+
+#SBATCH -o ./slurm_logs/%x-%j.out
+
+set -e
+set -o xtrace
+echo PWD:$(pwd)
+echo STARTING AT $(date)
+
+# Modules
+module purge
+module load gcc/9.3.0-cuda
+module load cuda/11.0.2
+
+# Environment
+source ~/miniconda3/etc/profile.d/conda.sh
+conda activate svglatte-pl
+export PYTHONPATH="$PYTHONPATH:$PWD/deepsvg"
+
+# Run
+date
+printf "Run configured and environment set up. Gonna run now.\n\n"
+python -m svglatte.train \
+ --experiment_name svg-latte-hparamsearch \
+ --experiment_version 'S15.02__BestHparams__NerfPositionalEncodings__Seed=72' \
+ --seed 72 \
+ --gpus -1 \
+ --n_epochs 600 \
+ --early_stopping_patience 80 \
+ --check_val_every_n_epoch 20 \
+ --batch_size 256 \
+ --encoder_lr 0.00042 \
+ --decoder_lr 2.1e-05 \
+ --encoder_weight_decay 0.0 \
+ --decoder_weight_decay 0.0 \
+ --encoder_type fc_lstm \
+ --lstm_num_layers 8 \
+ --latte_ingredients c \
+ --decoder_n_filters_in_last_conv_layer 16 \
+ --no_layernorm \
+ --cx_loss_w 0.0 \
+ --dataset argoverse \
+ --argoverse_sequences_format svgtensor_data \
+ --argoverse_train_sequences_path data/argoverse/train.sequences.torchsave \
+ --argoverse_val_sequences_path data/argoverse/val.sequences.torchsave \
+ --argoverse_test_sequences_path data/argoverse/test.sequences.torchsave \
+ --argoverse_train_workers 40 \
+ --argoverse_val_workers 3 \
+ --argoverse_rendered_images_width 128 \
+ --argoverse_rendered_images_height 128 \
+ --argoverse_augment_train --argoverse_zoom_preprocess_factor 0.70710678118 \
+ --precision 16 \
+ --gradient_clip_val 1.0 \
+ --seq_feature_dim 120
+
+echo FINISHED at $(date)

--- a/svglatte/scripts/slurm/sbatch/sbatch_15/svglatte-15-02.sh
+++ b/svglatte/scripts/slurm/sbatch/sbatch_15/svglatte-15-02.sh
@@ -60,6 +60,7 @@ python -m svglatte.train \
  --argoverse_augment_train --argoverse_zoom_preprocess_factor 0.70710678118 \
  --precision 16 \
  --gradient_clip_val 1.0 \
- --seq_feature_dim 120
+ --seq_feature_dim 120 \
+ --embedding_style nerf
 
 echo FINISHED at $(date)

--- a/svglatte/tests/test_gaussian_embedder.py
+++ b/svglatte/tests/test_gaussian_embedder.py
@@ -1,0 +1,57 @@
+# TODO refactor the location of tests
+
+import unittest
+
+import torch
+from absl.testing import parameterized
+
+from svglatte.utils.util import GaussianEmbedder
+
+
+class TestGaussianEmbedder(parameterized.TestCase):
+    @parameterized.product(
+        input_dims=[1, 2, 4],
+        scale=[1, 10],
+        embedding_size=[1, 30, 256],
+        seed=[72, 36],
+    )
+    def test_embed(self, input_dims, scale, embedding_size, seed):
+        embedder = GaussianEmbedder(
+            input_dims=input_dims,
+            scale=scale,
+            embedding_size=embedding_size,
+            seed=seed,
+        )
+
+        inputs = torch.randn(100, input_dims)
+        embeddings = embedder.embed(inputs)
+        assert embeddings.shape == (100, embedder.out_dim)
+
+        inputs_2 = torch.randn(input_dims)
+        embeddings_2 = embedder.embed(inputs_2)
+        assert embeddings_2.shape == (embedder.out_dim,)
+
+    def test_for_expected_embedding(self):
+        embedder = GaussianEmbedder(
+            input_dims=3,
+            scale=10,
+            embedding_size=10,
+            seed=72,
+        )
+        inputs = torch.tensor([[0, 0.5, 1], [-1, 0, 1]])
+        embeddings = embedder.embed(inputs)
+        
+        expected_embeddings = torch.tensor(
+            [[-0.6632360816001892, -0.9538021683692932, -0.9303285479545593, 0.7226450443267822, 0.7425926327705383,
+              -0.4597611725330353, 0.3829289674758911, -0.018863791599869728, 0.9841323494911194, 0.5045086145401001,
+              -0.7484102845191956, -0.3004353642463684, 0.36672714352607727, 0.6912193298339844, -0.6697433590888977,
+              -0.8880426287651062, 0.9237778186798096, -0.9998220801353455, -0.17743586003780365, -0.8634066581726074],
+             [-0.5181511640548706, -0.9389735460281372, -0.3012053966522217, 0.5573055148124695, 0.020015254616737366,
+              0.9685661196708679, -0.809158444404602, -0.9073007106781006, 0.997526228427887, -0.8431944251060486,
+              -0.8552890419960022, -0.34398943185806274, 0.9535592794418335, -0.8303074836730957, 0.9997996687889099,
+              -0.2487562596797943, -0.5875904560089111, -0.420482337474823, -0.07029476016759872, -0.5376087427139282]])
+        assert torch.equal(embeddings, expected_embeddings)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/svglatte/tests/test_nerf_embedder.py
+++ b/svglatte/tests/test_nerf_embedder.py
@@ -1,0 +1,122 @@
+# TODO refactor the location of tests
+
+import unittest
+
+import torch
+from absl.testing import parameterized
+
+from svglatte.utils.util import NerfEmbedder
+
+
+class TestNerfEmbedder(parameterized.TestCase):
+    @parameterized.product(
+        input_dims=[1, 2, 4],
+        include_input=[True, False],
+        max_freq_log2=[30, 14, 3],
+        num_freqs=[14, 4],
+        log_sampling=[True, False],
+        periodic_fns=[(torch.sin, torch.cos), (torch.sin,), (torch.relu, torch.sin)]
+    )
+    def test_create_embedding_fn(self, input_dims, include_input, max_freq_log2, num_freqs, log_sampling, periodic_fns):
+        embedder = NerfEmbedder(
+            include_input=include_input,
+            input_dims=input_dims,
+            num_freqs=num_freqs,
+            max_freq_log2=max_freq_log2,
+            log_sampling=log_sampling,
+            periodic_fns=periodic_fns,
+        )
+
+        assert embedder.include_input == include_input
+        assert embedder.input_dims == input_dims
+        assert embedder.max_freq_log2 == max_freq_log2
+        assert embedder.num_freqs == num_freqs
+        assert embedder.log_sampling == log_sampling
+        assert embedder.periodic_fns == periodic_fns
+        assert embedder.out_dim == input_dims * include_input + input_dims * num_freqs * len(periodic_fns)
+
+    @parameterized.product(
+        input_dims=[1, 2, 4],
+        include_input=[True, False],
+        max_freq_log2=[30, 14, 3],
+        num_freqs=[14, 4],
+        log_sampling=[True, False],
+        periodic_fns=[(torch.sin, torch.cos), (torch.sin,), (torch.relu, torch.sin)]
+    )
+    def test_embed(self, input_dims, include_input, max_freq_log2, num_freqs, log_sampling, periodic_fns):
+        embedder = NerfEmbedder(
+            include_input=include_input,
+            input_dims=input_dims,
+            num_freqs=num_freqs,
+            max_freq_log2=max_freq_log2,
+            log_sampling=log_sampling,
+            periodic_fns=periodic_fns,
+        )
+
+        inputs = torch.randn(100, input_dims)
+        embeddings = embedder.embed(inputs)
+        assert embeddings.shape == (100, embedder.out_dim)
+
+        inputs_2 = torch.randn(input_dims)
+        embeddings_2 = embedder.embed(inputs_2)
+        assert embeddings_2.shape == (embedder.out_dim,)
+
+    def test_for_expected_embedding_1(self):
+        periodic_fns = [torch.sin, torch.cos]
+        embedder = NerfEmbedder(
+            include_input=True,
+            input_dims=3,
+            num_freqs=4,
+            max_freq_log2=3,
+            log_sampling=True,
+            periodic_fns=periodic_fns,
+        )
+        inputs = torch.tensor([[0.15, 0.5, 0.72], [-1, 0, 1]])
+        embeddings = embedder.embed(inputs)
+
+        freq_bands = torch.tensor([1., 2., 4., 8.])
+        embedding_parts_list = [inputs]
+        for freq in freq_bands:
+            for fn in periodic_fns:
+                embedding_parts_list += [fn(inputs * freq)]
+                # for i in inputs:
+                #     for j in i:
+                #         print(f"{j:.4f} --> {j * freq:.4f} --> {fn(j):.4f} [freq={freq}] [fn={fn}]")
+        expected_embedding = torch.concat(embedding_parts_list, dim=-1)
+        assert torch.allclose(embeddings, expected_embedding)
+
+    def test_for_expected_embedding_2(self):
+        embedder = NerfEmbedder(
+            include_input=True,
+            input_dims=3,
+            num_freqs=4,
+            max_freq_log2=3,
+            log_sampling=True,
+            periodic_fns=[torch.sin, torch.cos],
+        )
+        inputs = torch.tensor([[0.15, 0.5, 0.72], [-1, 0, 1]])
+        embeddings = embedder.embed(inputs)
+
+        # print(embeddings.tolist())
+        # sed -i "s/,/,\n/3;P;D" tmp.txt
+        expected_embeddings = torch.tensor(
+            [[0.15000000596046448, 0.5, 0.7200000286102295,
+              0.14943814277648926, 0.4794255495071411, 0.6593846678733826,
+              0.9887710809707642, 0.8775825500488281, 0.7518057227134705,
+              0.29552021622657776, 0.8414709568023682, 0.9914583563804626,
+              0.9553365111351013, 0.5403023362159729, 0.1304236501455307,
+              0.5646424889564514, 0.9092974066734314, 0.2586192488670349,
+              0.8253356218338013, -0.416146844625473, -0.9659793376922607,
+              0.9320390820503235, -0.756802499294281, -0.49964168667793274,
+              0.3623577058315277, -0.6536436080932617, 0.86623215675354],
+             [-1.0, 0.0, 1.0,
+              -0.8414709568023682, 0.0, 0.8414709568023682, 0.5403023362159729, 1.0, 0.5403023362159729,
+              -0.9092974066734314, 0.0, 0.9092974066734314, -0.416146844625473, 1.0, -0.416146844625473,
+              0.756802499294281, 0.0, -0.756802499294281, -0.6536436080932617, 1.0, -0.6536436080932617,
+              -0.9893582463264465, 0.0, 0.9893582463264465, -0.1455000340938568, 1.0, -0.1455000340938568]]
+        )
+        assert torch.allclose(embeddings, expected_embeddings)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/svglatte/train.py
+++ b/svglatte/train.py
@@ -95,6 +95,8 @@ def get_parser_main_model():
     parser.add_argument('--clean_disk_cache', action='store_true', help='')
     parser.add_argument('--dataset', type=str, default='deepvecfont', choices=['deepvecfont', 'deepsvg', 'argoverse'])
     parser.add_argument('--standardize_input_sequences', action='store_true', help='')
+    parser.add_argument('--embedding_style', type=str, default=None,
+                        help='What input embedding style to use, see `utils.util.Embedder.factory`.')
     ## deepvecfont
     parser.add_argument('--deepvecfont_data_root', type=str, default='data/vecfont_dataset')
     parser.add_argument('--deepvecfont_max_seq_len', type=int, default=51, help='maximum length of sequence')
@@ -182,6 +184,7 @@ def get_dataset(config):
 
     if config.dataset == "deepvecfont":
         seq_feature_dim = deepvecfont_dataset.SEQ_FEATURE_DIM
+        assert config.embedding_style is None, "embedding_style not implemented for DeepVecFontDataModule"
         dm = deepvecfont_dataset.DeepVecFontDataModule(
             data_root=config.deepvecfont_data_root,
             max_seq_len=config.deepvecfont_max_seq_len,
@@ -202,6 +205,7 @@ def get_dataset(config):
             batch_size=config.batch_size,
             cache_to_disk=config.cache_to_disk,
             clean_disk_cache=config.clean_disk_cache,
+            embedding_style=config.embedding_style,
         )
     elif config.dataset == "argoverse":
         dm = argoverse_dataset.ArgoverseDataModule(
@@ -229,6 +233,7 @@ def get_dataset(config):
             augment_translate=config.argoverse_augment_translate,
             numericalize=config.argoverse_numericalize,
             canonicalize_svg=config.argoverse_canonicalize_svg,
+            embedding_style=config.embedding_style,
             **deepsvg_encoder_config_for_argoverse
         )
         # TODO:

--- a/svglatte/utils/util.py
+++ b/svglatte/utils/util.py
@@ -1,14 +1,26 @@
 import pathlib
+from abc import abstractmethod
 from datetime import datetime
 
 import torch
 
 
 class Object(object):
+    """
+    Empty class for use as a default placeholder object.
+    """
     pass
 
 
 def get_str_formatted_time() -> str:
+    """
+    Returns the current time in the format of '%Y.%m.%d_%H.%M.%S'.
+
+    Returns
+    -------
+    str
+        The current time in the specified format
+    """
     return datetime.now().strftime('%Y.%m.%d_%H.%M.%S')
 
 
@@ -33,6 +45,20 @@ HORSE = """               .,,.
 
 
 def nice_print(msg, last=False):
+    """
+    Print a message in a nice format.
+
+    Parameters
+    ----------
+    msg : str
+        The message to be printed
+    last : bool, optional
+        Whether to print a blank line at the end, by default False
+
+    Returns
+    -------
+    None
+    """
     print()
     print("\033[0;35m" + msg + "\033[0m")
     if last:
@@ -40,19 +66,290 @@ def nice_print(msg, last=False):
 
 
 class AttrDict(dict):
+    """
+    A dictionary class that can be accessed with attributes.
+    Note that the dictionary keys must be strings
+    and follow attribute naming rules to be accessible as attributes,
+    e.g., the key "123xyz" will give a syntax error.
+
+    Usage:
+    ```
+    x = AttrDict()
+    x["jure"] = "mate"
+    print(x.jure)
+    # "mate"
+
+    x[123] = "abc"
+    x.123
+    # SyntaxError: invalid syntax
+    ```
+    """
+
     def __init__(self, *args, **kwargs):
         super(AttrDict, self).__init__(*args, **kwargs)
         self.__dict__ = self
 
 
 def ensure_dir(dirname):
+    """
+    Ensure that a directory exists. If it doesn't, create it.
+
+    Parameters
+    ----------
+    dirname : str or pathlib.Path
+        The directory to be ensured
+
+    Returns
+    -------
+    None
+    """
     dirname = pathlib.Path(dirname)
     if not dirname.is_dir():
         dirname.mkdir(parents=True, exist_ok=False)
 
 
-def pad_collate_fn(batch, pad_value):
+class Embedder:
+    """
+    Abstract class for embedding input data.
+    """
+
+    @property
+    @abstractmethod
+    def out_dim(self):
+        """
+        The number of dimensions in the embedded data.
+
+        Returns
+        -------
+        int
+            The number of dimensions in the embedded data.
+        """
+        pass
+
+    @abstractmethod
+    def embed(self, x):
+        """
+        Embed the input data.
+
+        Parameters
+        ----------
+        x : torch.Tensor of shape [..., ndim]
+            The input data to be embedded
+
+        Returns
+        -------
+        torch.Tensor
+            The embedded data
+        """
+        pass
+
+    @staticmethod
+    def factory(embedding_style, **kwargs):
+        """
+        Factory method for creating instances of Embedder subclasses.
+
+        Parameters
+        ----------
+        embedding_style : str
+            The style of embedding to use, either "gaussian" or "nerf".
+        kwargs :
+            Keyword arguments passed to the corresponding subclass constructor.
+
+        Returns
+        -------
+        Embedder
+            An instance of a subclass of Embedder.
+        """
+        if embedding_style == "gaussian":
+            return GaussianEmbedder(**kwargs)
+        elif embedding_style == "nerf":
+            return NerfEmbedder(**kwargs)
+        else:
+            raise RuntimeError("")
+
+
+class GaussianEmbedder(Embedder):
+    """
+    A class for embedding 2D inputs to a higher dimensional space
+    using frequencies randomly sampled from the Gaussian distribution.
+
+    Parameters
+    ----------
+    input_dims : int, optional
+        The dimensionality of the vectors to be embedded, e.g. 2 for 2D coordinates, 3 for 3D coordinates
+    scale : int, optional
+        The scale of the randomly sampled Gaussian distribution
+    embedding_size : int, optional
+        The size of the outputted embedding, i.e., the number
+
+    Attributes
+    ----------
+    generator : torch.Generator
+        The torch random number generator
+    freq : torch.Tensor of shape (embedding_size, ndim)
+        The embedding frequencies that were randomly sampled from the Gaussian distribution
+    amplitude : torch.Tensor of shape (embedding_size,)
+        The amplitude of the sinusoidal and cosinusoidal functions
+    """
+
+    def __init__(self, input_dims=2, scale=12, embedding_size=256, seed=72):
+        self.embedding_size = embedding_size
+        self.input_dims = input_dims
+        self.scale = scale
+        self.seed = seed
+
+        self.generator = torch.Generator()
+        self.generator.manual_seed(self.seed)
+        self.freq = self.scale * torch.randn((self.embedding_size, self.input_dims), generator=self.generator)
+        self.amplitude = torch.ones((self.freq.shape[0]))
+
+        self._out_dim = embedding_size * 2
+
+    def embed(self, x):
+        return torch.concat([self.amplitude * torch.sin((2. * torch.pi * x) @ self.freq.T),
+                             self.amplitude * torch.cos((2. * torch.pi * x) @ self.freq.T)], dim=-1)
+
+    @property
+    def out_dim(self):
+        return self._out_dim
+
+
+class NerfEmbedder(Embedder):
+    """
+    A class for embedding data using powers of two as frequencies.
+    Modified from a PyTorch implementation of Neural Radiance Fields (NeRF):
+    https://github.com/yenchenlin/nerf-pytorch/blob/63a5a630c9abd62b0f21c08703d0ac2ea7d4b9dd/run_nerf_helpers.py#L15
+
+    Parameters
+    ----------
+    include_input : bool, optional
+        Whether to include the input in the embedding
+    input_dims : int, optional
+        The dimensionality of the vectors to be embedded, e.g. 2 for 2D coordinates, 3 for 3D coordinates
+    max_freq_log2 : int, optional
+        The maximum frequency, given as log2 of the frequency, e.g. 10 would correspond to a max frequency of 2^10
+    num_freqs : int, optional
+        The number of frequencies to use
+    log_sampling : bool, optional
+        Whether to sample the frequencies logarithmically or uniformly, e.g. [1,2,4,8,16] or [1.0,4.75,8.5,12.25,16.0]
+    periodic_fns : tuple, optional
+        The periodic functions to use in the embedding (e.g. sin, cos)
+    """
+
+    def __init__(
+            self,
+            include_input=True,
+            input_dims=2,
+            num_freqs=14,
+            max_freq_log2=14 - 1,
+            log_sampling=True,
+            periodic_fns=(torch.sin, torch.cos)
+    ):
+        self.include_input = include_input
+        self.input_dims = input_dims
+        self.max_freq_log2 = max_freq_log2
+        self.num_freqs = num_freqs
+        self.num_freqs = num_freqs
+        self.log_sampling = log_sampling
+        self.periodic_fns = periodic_fns
+
+        self._create_embedding_fn()
+
+    def _create_embedding_fn(self):
+        embed_fns = []
+        d = self.input_dims
+        out_dim = 0
+        if self.include_input:
+            embed_fns.append(lambda x: x)
+            out_dim += d
+
+        if self.log_sampling:
+            freq_bands = 2. ** torch.linspace(0., self.max_freq_log2, steps=self.num_freqs)
+        else:
+            freq_bands = torch.linspace(2. ** 0., 2. ** self.max_freq_log2, steps=self.num_freqs)
+
+        for freq in freq_bands:
+            for p_fn in self.periodic_fns:
+                embed_fns.append(lambda x, p_fn=p_fn, freq=freq: p_fn(x * freq))
+                out_dim += d
+
+        self._embed_fns = embed_fns
+        self._out_dim = out_dim
+
+    def embed(self, x):
+        return torch.cat([fn(x) for fn in self._embed_fns], -1)
+
+    @property
+    def out_dim(self):
+        return self._out_dim
+
+
+def resize_coordinate(x):
+    """
+    Resize input tensor from [0, 24] to [-1,+1].
+    """
+    assert x.max() <= 24
+    assert x.min() >= -1
+    return (x - 12) / 12
+
+
+def identity_fn(x):
+    return x
+
+
+def embed_sequences(sequences, embedder: Embedder, resize_fn=identity_fn):
+    """
+    Embed the given sequences.
+
+    Parameters
+    ----------
+    sequences : list of tensors
+        List of tensors, where each tensor has shape (N, D),
+        where N is the number of vectors in the sequence
+        and D is the number of dimensions of each vector.
+    embedder : Embedder
+        An instance of the Embedder class, which will perform the embedding of the input points.
+    resize_fn : callable, optional
+        A function to apply to each input sequence before embedding.
+
+    Returns
+    -------
+    list of tensors
+        List of tensors, where each tensor has shape (N, embedder.out_dim), where N is the number of points in the
+        sequence and out_dim is the number of dimensions in the embedded space.
+    """
+    embedded_sequences = [
+        torch.concat([
+            seq[:, :4],  # TODO hardcoded sequence positions
+            embedder.embed(resize_fn(seq[:, 6:8])),  # TODO hardcoded sequence positions
+            embedder.embed(resize_fn(seq[:, 4:6])),  # TODO hardcoded sequence positions
+        ], dim=1)
+        for seq in sequences
+    ]
+    return embedded_sequences
+
+
+def pad_collate_fn(batch, pad_value, embedder: Embedder = None):
+    """
+    Function for padding sequences in a batch.
+
+    Parameters
+    ----------
+    batch : List of tuples
+        A list of tuples, each containing a sequence, image, and length.
+    pad_value : float
+        The value used for padding the sequences.
+    embedder : Embedder, optional
+        An instance of the Embedder class.
+
+    Returns
+    -------
+    torch.Tensor, torch.Tensor, torch.Tensor
+        The padded sequences, images, and lengths.
+    """
     sequences, images, lengths = zip(*batch)
+    if embedder is not None:
+        sequences = embed_sequences(sequences, embedder, resize_coordinate)
     images = torch.cat(images).unsqueeze(1)
     lengths = torch.tensor(lengths)
     padded_sequences = torch.nn.utils.rnn.pad_sequence(sequences, padding_value=pad_value, batch_first=True)

--- a/svglatte/utils/util.py
+++ b/svglatte/utils/util.py
@@ -19,7 +19,7 @@ def get_str_formatted_time() -> str:
     Returns
     -------
     str
-        The current time in the specified format
+        The current time
     """
     return datetime.now().strftime('%Y.%m.%d_%H.%M.%S')
 
@@ -68,8 +68,8 @@ def nice_print(msg, last=False):
 class AttrDict(dict):
     """
     A dictionary class that can be accessed with attributes.
-    Note that the dictionary keys must be strings
-    and follow attribute naming rules to be accessible as attributes,
+    Note that the dictionary keys must be strings and
+    follow attribute naming rules to be accessible as attributes,
     e.g., the key "123xyz" will give a syntax error.
 
     Usage:
@@ -97,7 +97,7 @@ def ensure_dir(dirname):
     Parameters
     ----------
     dirname : str or pathlib.Path
-        The directory to be ensured
+        The directory, the existence of which will be ensured
 
     Returns
     -------
@@ -180,7 +180,7 @@ class GaussianEmbedder(Embedder):
     scale : int, optional
         The scale of the randomly sampled Gaussian distribution
     embedding_size : int, optional
-        The size of the outputted embedding, i.e., the number
+        The size of the outputted embedding
 
     Attributes
     ----------


### PR DESCRIPTION
## Describe your changes
1. Implemented and tested NeRF-style positional embeddings of the input
   coordinates.

Limitations:
- End-to-end tests missing
- The location of tests might need refactoring; possibly we want to
  refactor the whole project
- When doing padding, the positions of the coordinates in the sequence
  are hardcoded to the sequence format of the Argoverse line dataset
- The parameter `seq_feature_dim` must be provided from the command line
  and is not inferred automatically

## Checklist before requesting a review
- [x] I have performed a self-review of my code

## Tests

```bash
cd root_of_repository

# Prepare environment
conda activate svglatte
pip install pytest
export PYTHONPATH="$PYTHONPATH:$PWD/deepsvg"

# Run all tests
python -m pytest
```

## Experiment Takeaways
1.  Positional encodings resulted in a 10% performance boost on the test
    set in our task, lowering the test loss from 0.0197 to 0.0176.
2. The convergence is sublinear in any case (i.e., a line on a log-log
   plot), which is very slow and requires a lot of iterations to
   converge. Thus, even after 600 epochs, we do not converge.
3. The qualitative results look mostly equal. Even though the loss is
   getting smaller, it is hard to notice the differences in the
   outputted images. Some fine details might be reconstructed better
   with positional embeddings used. But seems hard to make a strong case
   for that, given that it is very hard to spot any differences.

## Discussion
**Lacking motivation.** It's unclear how to apply the benefits of
positional encodings for our task, which differs from coordinate-based
MLP tasks like NeRF where the encoding proved to be crucial. Our task
does not involve learning a function that is queried for different
positions in space, as opposed to coordinate-based MLPs. Given that
there is no initial indication that positional encodings would be a
silver bullet, it may not be a worthwhile direction to pursue.

**Motivation in NeRF.** In the case of NeRF, the use of positional
encodings is motivated by the "spectral bias" \cite{[rahaman2018spectral-bias](https://arxiv.org/pdf/1806.08734.pdf)}
of deep neural networks. Coordinate-based MLP networks have difficulty
learning high-frequency functions of low dimensional inputs
\cite{[mildenhall2020nerf](https://arxiv.org/pdf/2003.08934.pdf), [tancik2020fourier](https://arxiv.org/pdf/2006.10739.pdf), [mueller2022instant](https://arxiv.org/pdf/2201.05989.pdf)}, limiting
their performance. Mapping the inputs to a higher dimensional space
using high-frequency functions addresses this issue and allows the
network to better fit the high-frequency variation in the data. Neural
tangent kernel theory suggests that this might be because standard
coordinate-based MLPs correspond to kernels with a rapid frequency
falloff, not allowing them to represent the high-frequency content
present in natural images and scenes.

**Better than a simple linear layer.**
`[TODO: revisit kernel methods, find a more convincing argument]`
Regarding the use of a simple linear layer instead of positional
encodings, it's possible for the first layers of the MLP to learn the
embedding themselves. However, I believe that this approach would
require one-hot encoding of the input coordinate and a separate set of
learnable parameters for each coordinate value (e.g., for a discrete
coordinate, x=1, x=2, ..., x=256), similar to the word2vec or glove in
NLP. These parameters might be tunable or fixed to extract
high-frequency Fourier features.
